### PR TITLE
40MB以上の動画がアップロードできない問題を修正

### DIFF
--- a/src/TwitterAds.php
+++ b/src/TwitterAds.php
@@ -433,6 +433,8 @@ class TwitterAds extends Config
         // Append
         $segment_index = 0;
         $media = fopen($parameters['media'], 'rb');
+        // チャンクの単位となるバイト数を取得（チャンク数は0〜999までなので、ファイルの合計バイト数を1000で割る）
+        $upload_chunk = intval(ceil(filesize($parameters['media'])/1000));
         while (!feof($media)) {
             $this->http(
                 'POST',
@@ -442,7 +444,7 @@ class TwitterAds extends Config
                     'command' => 'APPEND',
                     'media_id' => $init->media_id_string,
                     'segment_index' => $segment_index++,
-                    'media_data' => base64_encode(fread($media, self::UPLOAD_CHUNK)),
+                    'media_data' => base64_encode(fread($media, $upload_chunk)),
                 ]
             )->getBody();
         }


### PR DESCRIPTION
## 事象
40MB以上の動画を広告用メディアとしてアップロードした場合、「BAD REQUSET」としてエラーが返却される

## 原因
メディアファイルの分割アップロードが原因でした。
1. メディアアップロードAPIはチャンク数を1000までしか受け付けることができない
2. ファイルを分割するサイズの単位が固定値で決まっている

以上の条件によって、特定サイズ以上のファイルは1001個以上のチャンク数を保持することになり、メディアのアップロードが正常に行われていませんでした。
（固定値40960KB * 1000 = 40960000byte（約40MB） で、40MB以上の動画をアップロードすることができない）

- メディアアップロードAPIはチャンク数を1000までしか受け付けることができない

https://developer.twitter.com/ja/docs/media/upload-media/api-reference/post-media-upload-append

|名前 |要否 |説明 |デフォルト値 |例|
|--|--|--|--|--|
|segment_index |必須 |ファイルのチャンクに順番に付けられたインデックスです。必ず0～999の間の数字になります（両方の数字を含む）。最初のセグメントのインデックスは0、2つ目のセグメントのインデックスは1で、以下、同様に処理されます。|

- ファイルを分割するサイズの単位が固定値で決まっている
https://github.com/goroakimoto/twitter-php-ads-sdk/blob/e26fb5af5554debc168b2ead7317441119c707f3/src/TwitterAds.php#L32

- ファイルサイズごとに分割してアップロードを行う処理
https://github.com/goroakimoto/twitter-php-ads-sdk/blob/e26fb5af5554debc168b2ead7317441119c707f3/src/TwitterAds.php#L433-L448

## 修正
### src/TwitterAds.php
#### 画像の分割アップロードメソッド（private function uploadMediaChunked($path, $parameters)）
- チャンク数の単位となるバイト数を、ファイルサイズから動的に出力するようにしました